### PR TITLE
Update I2C transceive

### DIFF
--- a/adafruit_mlx90393.py
+++ b/adafruit_mlx90393.py
@@ -164,16 +164,13 @@ class MLX90393:
             with self.i2c_device as i2c:
                 i2c.write(payload, stop=False)
 
-            while True:
-                # While busy, the sensor doesn't respond to reads.
-                try:
-                    with self.i2c_device as i2c:
+                while True:
+                    try:
                         i2c.readinto(data)
-                        # Make sure we have something in the response
                         if data[0]:
                             break
-                except OSError:
-                    pass
+                    except OSError:
+                        pass
 
         # Track status byte
         self._status_last = data[0]


### PR DESCRIPTION
This should fix:
https://github.com/adafruit/Adafruit_CircuitPython_TCA9548A/issues/19

The TCA9548 library switches all channels "off" at the exit of a context manager, which calls `unlock()`:
https://github.com/adafruit/Adafruit_CircuitPython_TCA9548A/blob/687a11e6ea197da3722e3202d2eda93ad75d3fc9/adafruit_tca9548a.py#L71
As a result, an I2C STOP is generated.

This PR consolidates two context managers which was causing an I2C STOP to be generated between to the separate I2C write and reads in one branch of the `_transceive()` code.

```python
Adafruit CircuitPython 5.3.0 on 2020-04-29; Adafruit ItsyBitsy M4 Express with samd51g19
>>> import board, busio, adafruit_mlx90393, adafruit_tca9548a
>>> tca = adafruit_tca9548a.TCA9548A(board.I2C())
>>> mlx = adafruit_mlx90393.MLX90393(tca[7])
>>> mlx.magnetic
(-300.15, 40.95, 181.016)
>>> mlx.magnetic
(1960.95, -3556.95, 7551.12)
>>>
```