### PR TITLE
Remove stop kwarg

### DIFF
--- a/adafruit_mlx90393.py
+++ b/adafruit_mlx90393.py
@@ -215,8 +215,7 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
             # Write 'value' to the specified register
             # TODO: Check this. It's weird that the write is accepted but the read is naked.
             with self.i2c_device as i2c:
-                # pylint: disable=unexpected-keyword-arg
-                i2c.write(payload, stop=False)
+                i2c.write(payload)
 
                 while True:
                     try:


### PR DESCRIPTION
For #18.

Quick and simple test just to make sure basics still work.
```python
Adafruit CircuitPython 5.3.1 on 2020-07-13; Adafruit ItsyBitsy M0 Express with samd21g18
>>> import board
>>> import adafruit_mlx90393
>>> mlx = adafruit_mlx90393.MLX90393(board.I2C())
>>> mlx.magnetic
(-22.95, -32.85, -37.026)
>>> 
```