### PR TITLE
Fix bug in reset that wasn't setting status properly

### DIFF
--- a/adafruit_mlx90393.py
+++ b/adafruit_mlx90393.py
@@ -386,7 +386,7 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
         if self._debug:
             print("Resetting sensor")
         time.sleep(2)
-        self._status_last = self._transceive(bytes([_CMD_RT]))
+        self._transceive(bytes([_CMD_RT]))
         # burn a read post reset
         try:
             self.magnetic


### PR DESCRIPTION
Removed setting the `_status_last` to the return value as the return result isn't just the status field.
The `_transceive` function is actually setting the `_status_last` as part of the function so there is no need to do anything additional in reset

This addresses Issue: https://github.com/adafruit/Adafruit_CircuitPython_MLX90393/issues/25