### PR TITLE
adding temperature reading

### DIFF
--- a/adafruit_mlx90393.py
+++ b/adafruit_mlx90393.py
@@ -520,14 +520,17 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
 
         return x, y, z
 
-    def read_temp(self):
+    @property
+    def temperature(self) -> float:
         """
         Reads a single temperature sample from the magnetometer.
+        Temperature value in Celsius
         """
-        # Set conversion delay based on filter and oversampling
+        # Read the temperature reference from register 0x24
         treference = self.read_reg(0x24)
 
-        # from maximum time of temperature conversion on the datasheet section 12. 1603 us
+        # Value taken from maximum time of temperature conversion on the datasheet section 12.
+        # maximum time for temperature conversion = 1603 us
         delay = 0.1
 
         # Set the device to single measurement mode
@@ -544,6 +547,6 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
         # from https://www.melexis.com/-/media/files/documents/
         # application-notes/mlx90393-temperature-compensation-application-note-melexis.pdf
         tvalue = struct.unpack(">H", data[1:3])[0]
-        temperature = 35 + ((tvalue - treference) / 45.2)  # See previous link
+        # See previous link for conversion formula
 
-        return temperature
+        return 35 + ((tvalue - treference) / 45.2)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,12 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/mlx90393_simpletest.py
     :caption: examples/mlx90393_simpletest.py
     :linenos:
+
+Temperature test
+-----------------
+
+Example showing how to measure temperature with the sensor
+
+.. literalinclude:: ../examples/mlx90393_temperature.py
+    :caption: examples/mlx90393_temperature.py
+    :linenos:

--- a/examples/mlx90393_temperature.py
+++ b/examples/mlx90393_temperature.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2023 Jose D. Montoya
+# SPDX-License-Identifier: MIT
+
+import time
+import board
+import adafruit_mlx90393
+
+i2c = board.I2C()  # uses board.SCL and board.SDA
+# i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
+SENSOR = adafruit_mlx90393.MLX90393(i2c, gain=adafruit_mlx90393.GAIN_1X)
+
+
+while True:
+    temp = SENSOR.temperature
+
+    print("Temperature: {} °C".format(temp))
+
+    # Display the status field if an error occurred, etc.
+    if SENSOR.last_status > adafruit_mlx90393.STATUS_OK:
+        SENSOR.display_status()
+    time.sleep(1.0)


### PR DESCRIPTION
PR is to add the ability to read the temperature provided by the sensor. solves #32 

### Dessign Choices

1. I did not include the temperature as a @property as the library is already big, and I do no beleive that the purpose of the sensor is to measure temperature.
2. We could read the 4 values at the same time changing `_CMD_AXIS_ALL` to  = const(0xF) , and give them to the user, however I choose not to, because sensor application. Temeprature will need to read register 0x24 adding time to get the value.
3. Put the temperature reading as a optional for folks that would need it

PR could be test using the following script

```python

# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
# SPDX-License-Identifier: MIT

import time
import board
import adafruit_mlx90393

i2c = board.I2C()  # uses board.SCL and board.SDA
# i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
SENSOR = adafruit_mlx90393.MLX90393(i2c, gain=adafruit_mlx90393.GAIN_1X)


while True:
    MX, MY, MZ = SENSOR.magnetic
    print("X: {} uT".format(MX))
    print("Y: {} uT".format(MY))
    print("Z: {} uT".format(MZ))

    # Display the status field if an error occured, etc.
    if SENSOR.last_status > adafruit_mlx90393.STATUS_OK:
        SENSOR.display_status()
    print("Temperature: {}C".format(SENSOR.read_temp()))
    # Display the status field if an error occured, etc.
    if SENSOR.last_status > adafruit_mlx90393.STATUS_OK:
        SENSOR.display_status()
    time.sleep(1.0)



```