### PR TITLE
Update read_reg() to use repeated start

### DIFF
--- a/adafruit_mlx90393.py
+++ b/adafruit_mlx90393.py
@@ -406,15 +406,12 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
 
         :param int reg: The register to read
         """
-        # Write 'value' to the specified register
+        # Read register
         payload = bytes([_CMD_RR, reg << 2])
-        with self.i2c_device as i2c:
-            i2c.write(payload)
-
-        # Read the response (+1 to account for the mandatory status byte!)
         data = bytearray(3)
         with self.i2c_device as i2c:
-            i2c.readinto(data)
+            i2c.write_then_readinto(payload, data)
+
         # Unpack data (status byte, big-endian 16-bit register value)
         self._status_last, val = struct.unpack(">BH", data)
         if self._debug:


### PR DESCRIPTION
Possible fix for #37.

Basically just switches to using a repeated start in the `read_reg()` function.

All of the I2C examples in the MLX90393 datasheet show repeated start. The MLX90393 seems to be somewhat OK with a stop/start split write/read transaction, since that is used in a few places. But that mixed with the additional I2C overhead dealing with setting the muxer does not seem to work (see traces in issue thread).

Tested with QT PY RP2040 + PCA9546A + MLX90393, the same setup that was failing before, works now:
```python
Adafruit CircuitPython 8.2.6 on 2023-09-12; Adafruit QT Py RP2040 with rp2040
>>> import board
>>> import adafruit_mlx90393
>>> import adafruit_tca9548a
>>> i2c = board.STEMMA_I2C()
>>> mux = adafruit_tca9548a.PCA9546A(i2c)
>>> SENSOR = adafruit_mlx90393.MLX90393(mux[2], address=0x0c)
>>> SENSOR.magnetic
(-34.35, -9.9, 78.65)
>>> SENSOR.magnetic
(-34.2, -10.05, 78.65)
>>> SENSOR.magnetic
(-595.95, -68.1, -163.592)
>>>
```

And still works without the muxer and simply connected directly:
```python
Adafruit CircuitPython 8.2.6 on 2023-09-12; Adafruit QT Py RP2040 with rp2040
>>> import board
>>> import adafruit_mlx90393
>>> i2c = board.STEMMA_I2C()
>>> SENSOR = adafruit_mlx90393.MLX90393(i2c, address=0x0c)
>>> SENSOR.magnetic
(-44.4, 2.25, 55.176)
>>> 
```