### PR TITLE
Adds temperature compensation

### DIFF
--- a/adafruit_mlx90393.py
+++ b/adafruit_mlx90393.py
@@ -484,14 +484,13 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
         if self._temperature_compensation and not resolutions.issubset(
             valid_tcomp_resolutions
         ):
-            resolutions_output = (
-                f"Current Resolutions:\n\t"
-                f"resolution_x: {self.resolution_x}\n\t"
-                f"resolution_y: {self.resolution_y}\n\t"
-                f"resolution_z: {self.resolution_z}"
-            )
+            resolutions_output = f"""Current Resolutions:
+\tresolution_x: {self.resolution_x}
+\tresolution_y: {self.resolution_y}
+\tresolution_z: {self.resolution_z}"""
+
             raise ValueError(
-                f"All resolutions must be RESOLUTION_16 or RESOLUTION_17"
+                "All resolutions must be RESOLUTION_16 or RESOLUTION_17"
                 f" if temperature compensation is enabled.\n {resolutions_output}"
             )
 

--- a/adafruit_mlx90393.py
+++ b/adafruit_mlx90393.py
@@ -484,9 +484,15 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
         if self._temperature_compensation and not resolutions.issubset(
             valid_tcomp_resolutions
         ):
-            resolutions_output = f"Current Resolutions:\n\tresolution_x: {self.resolution_x}\n\tresolution_y: {self.resolution_y}\n\tresolution_z: {self.resolution_z}"
+            resolutions_output = (
+                f"Current Resolutions:\n\t"
+                f"resolution_x: {self.resolution_x}\n\t"
+                f"resolution_y: {self.resolution_y}\n\t"
+                f"resolution_z: {self.resolution_z}"
+            )
             raise ValueError(
-                f"All resolutions must be RESOLUTION_16 or RESOLUTION_17 if temperature compensation is enabled.\n {resolutions_output}"
+                f"All resolutions must be RESOLUTION_16 or RESOLUTION_17"
+                f" if temperature compensation is enabled.\n {resolutions_output}"
             )
 
         # Set conversion delay based on filter and oversampling


### PR DESCRIPTION
Adds logic to enable temperature compensation
Since this feature pretty much requires access to the offset properties, they should be added as well.
I didn't have time today, but might add them tomorrow.

Fixes https://github.com/adafruit/Adafruit_CircuitPython_MLX90393/issues/36

