### PR TITLE
Remove delay in reset function

### DIFF
--- a/adafruit_mlx90393.py
+++ b/adafruit_mlx90393.py
@@ -465,7 +465,6 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
         self._transceive(bytes([_CMD_EX]))
         if self._debug:
             print("Resetting sensor")
-        time.sleep(2)
         self._transceive(bytes([_CMD_RT]))
         # burn a read post reset
         try:


### PR DESCRIPTION
Fixes issue in #42 

As per testing and suggestion, no need for a 2 second sleep between the exit and reset calls inside the reset function.