### PR TITLE
Add Axis Offset Compensation

### DIFF
--- a/adafruit_mlx90393.py
+++ b/adafruit_mlx90393.py
@@ -443,7 +443,7 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
         self._off_z = offset
 
     def _set_offset(self, axis: int, offset: int) -> None:
-        if offset < 0x0000 or offset > 0xFFFF :
+        if offset < 0x0000 or offset > 0xFFFF:
             raise ValueError("Incorrect offset setting.")
         if axis == 0:
             self.write_reg(_CMD_REG_CONF5, offset)


### PR DESCRIPTION
> It's pretty simple to do I think, so I would recommend at least giving it a shot if you can

_Originally posted by @purepani in https://github.com/adafruit/Adafruit_CircuitPython_MLX90393/issues/39#issuecomment-2499282196_

Adding these properties as it is needed when enabling temperature compensation.

Temperature compensation disabled, no offsets
```
X: -43.5 uT
Y: -47.1 uT
Z: 13.068 uT
```

Temperature compensation enabled, no offsets
```
X: 8973.9 uT
Y: 8969.4 uT
Z: 14551.944 uT
```

Temperature compensation enabled, 0x8000 offset for all axes
```
X: -39.3 uT
Y: -42.6 uT
Z: 12.1 uT
```