### PR TITLE
Add Temperature Oversampling

### DIFF
--- a/adafruit_mlx90393.py
+++ b/adafruit_mlx90393.py
@@ -215,6 +215,7 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
         filt: int = FILTER_7,
         oversampling: int = OSR_3,
         temperature_compensation: bool = False,
+        temperature_oversampling: int = OSR_0,
         offset: int = 0,
         debug: bool = False,
     ) -> None:
@@ -226,6 +227,7 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
         self._osr = oversampling
         self._gain_current = gain
         self._temperature_compensation = temperature_compensation
+        self._osr2 = temperature_oversampling
         # Typical value according the application note
         self._tref = 0xB668
         self._off_x = self._off_y = self._off_z = offset
@@ -247,6 +249,7 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
         # Set gain to the supplied level
         self.gain = self._gain_current
         self.temperature_compensation = self._temperature_compensation
+        self.temperature_oversampling = self._osr2
 
         # Set offsets to supplied level
         self.offset_x = self._off_x
@@ -387,7 +390,7 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
 
     @property
     def oversampling(self) -> int:
-        """The oversampling level."""
+        """The magnetic sensor oversampling level."""
         return self._osr
 
     @oversampling.setter
@@ -413,6 +416,21 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
         reg |= temperature_compensation << t_cmp_bit
         self.write_reg(_CMD_REG_CONF2, reg)
         self._temperature_compensation = temperature_compensation
+
+    @property
+    def temperature_oversampling(self) -> int:
+        """The temperature sensor oversampling level."""
+        return self._osr2
+
+    @temperature_oversampling.setter
+    def temperature_oversampling(self, level: int) -> None:
+        if level not in range(4):
+            raise ValueError("Incorrect oversampling level.")
+        reg = self.read_reg(_CMD_REG_CONF3)
+        reg &= 0xE7FF
+        reg |= (level & 0x3) << 12
+        self.write_reg(_CMD_REG_CONF3, reg)
+        self._osr2 = level
 
     @property
     def offset_x(self) -> int:

--- a/adafruit_mlx90393.py
+++ b/adafruit_mlx90393.py
@@ -249,7 +249,6 @@ class MLX90393:  # pylint: disable=too-many-instance-attributes
         # Set gain to the supplied level
         self.gain = self._gain_current
         self.temperature_compensation = self._temperature_compensation
-        self.temperature_oversampling = self._osr2
 
         # Set offsets to supplied level
         self.offset_x = self._off_x


### PR DESCRIPTION
Similar to #22 but for temperature oversampling.

The `0xE7FF` mask comes from manipulating bits 12 and 13 of the register: so `1110 0111 1111 1111` in hex

The internal OSR2 name is what the datasheet calls this parameter. No reason to have separate settings for this as it uses the same values as the existing OSR ones.

```python
mlx.temperature_oversampling = adafruit_mlx90393.OSR_3
```

@FoamyGuy could you review?